### PR TITLE
bootstrap 응용한 웹 페이지 1면 완, 2면 완?...

### DIFF
--- a/Web/flask-darkflow_YS/0312/server0312.py
+++ b/Web/flask-darkflow_YS/0312/server0312.py
@@ -6,11 +6,11 @@ import tensorflow as tf
 
 app = Flask(__name__, static_url_path='/static')
 
-# options = {"model": "./cfg/handlang-small.cfg",
-#            "metaLoad": "./darkflow/built_graph/handlang-small.meta",
-#            "pbLoad": './darkflow/built_graph/handlang-small.pb', "threshold": 0.4}
+options = {"model": "./cfg/handlang-small.cfg",
+           "metaLoad": "./darkflow/built_graph/handlang-small.meta",
+           "pbLoad": './darkflow/built_graph/handlang-small.pb', "threshold": 0.4}
 
-options = {"model": "./cfg/yolo.cfg", "load": "./bin/yolov2.weights", "threshold": 0.4}
+# options = {"model": "./cfg/yolo.cfg", "load": "./bin/yolov2.weights", "threshold": 0.4}
 
 tfnet = TFNet(options)
 
@@ -82,6 +82,10 @@ def quiz():
 def numstudy():
     return render_template('numstudy.html')
 
+
+@app.route('/selectChar')
+def selectChar():
+    return render_template('selectChar.html')
 
 @app.route('/return_label')
 def return_label():

--- a/Web/flask-darkflow_YS/0312/templates/charstudy.html
+++ b/Web/flask-darkflow_YS/0312/templates/charstudy.html
@@ -8,7 +8,7 @@
     <title>핸들랭(Handlang) 수화 교육 프로젝트 🍩</title>
 
     <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css">
-
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
     <style>
         body {
@@ -32,13 +32,13 @@
                     <a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/charstudy">지문자 연습</a>
+                    <a class="nav-link" href="{{url_for('charstudy')}}">지문자 연습</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/quiz">지문자 퀴즈</a>
+                    <a class="nav-link" href="{{url_for('quiz')}}">지문자 퀴즈</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/numstudy">숫자 연습</a>
+                    <a class="nav-link" href="{{url_for('numstudy')}}">숫자 연습</a>
                 </li>
             </ul>
         </div>
@@ -48,38 +48,73 @@
     <div class="container">
 
       <div class="row">
+
         <div class="col-sm-6">
-          <img style="margin-top: 10%" src="/static/images/A_2019-02-26-100450%20resized.jpg">
+            <!--          ASL image-->
+            <img style="width:100%; height:auto; margin-top: 10%" src="/static/images/A_2019-02-26-100450%20resized.jpg">
+            <!--            img Label-->
+            <br><br><br>
+            <p style=" width:100%; height: 30%; font-size: 400%; text-align: center;">Aa</p>
         </div>
+
+          <!--          webcam -->
         <div class="col-sm-6">
-            <img style="margin-top: 10%" id="video" src="{{ url_for('video_feed') }}" width="100%">
-            <div id="predict" style="text-align: center;">
-            <br>🤔 현재 predict label 🤔<br>
-            예측을 시작하려면 Enter키↩️ 를 눌러주세요.
-            <div id="predict-in"
-                 style="margin-top: 10px; line-height: 1.4em; border:1px dashed steelblue; font-size: 500%; text-align: center;">
-                Not Started.
-                <br>
+            <img style="margin-top: 10%; width:100%; height:60%" id="video" src="{{ url_for('video_feed') }}">
+            <div id="predict" style="text-align: center; ">
+                <br>🤔 현재 predict label 🤔<br>
+                예측을 시작하려면 Enter키↩️ 를 눌러주세요.
+                <div id="predict-in"
+                     style="margin-top: 10px; line-height: 1.4em; border:1px dashed steelblue; font-size: 400%; text-align: center;">
+                    Not Started.
+                </div>
             </div>
         </div>
       </div>
 
+          <!--          경계선-->
+        <hr style="border: 0; height: 3px; background: #ccc;">
+
       <div class="row">
         <div class="col-sm-6">
-<!--            a-z 라벨 링크-->
+            <!--            알파벳 선택하기 버튼-->
+            <div class="btn btn-primary btn-block p-3" href="{{ url_for('selectChar') }}"> 지문자 선택하러 가기</div>
         </div>
-        </div>
+
         <div class="col-sm-6">
-<!--          ok 싸인 10개-->
+
+            <!--          ok 싸인 by 지영언니-->
+
+            <table class="table table-sm table-bordered table-warning text-center">
+                <thead>
+                    <tr>
+                        <td>1</td>
+                        <td>2</td>
+                        <td>3</td>
+                        <td>4</td>
+                    </tr>
+                </thead>
+                <thead>
+                    <tr>
+                        <td>5</td>
+                        <td>6</td>
+                        <td>7</td>
+                        <td>8</td>
+                    </tr>
+                </thead>
+            </table>
+        <a style="float: right;" href="#" title="다음"> <i class="fa fa-arrow-circle-right" style="font-size:60px"></i></a>
+
         </div>
+
       </div>
 
     </div>
-<!--다음 알파벳으-->로
+    <!--다음 알파벳으로-->
+
       <hr>
 
       <footer>
-        <p>&copy; 핸들랭(Handlang)</p>
+        <p style="text-align: center;">&copy; 핸들랭(Handlang)</p>
       </footer>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/Web/flask-darkflow_YS/0312/templates/index.html
+++ b/Web/flask-darkflow_YS/0312/templates/index.html
@@ -81,17 +81,17 @@
       <div class="row">
         <div class="col-md-4">
 <!--          <div class="btn">-->
-            <a class="btn btn-primary btn-block p-6" href="/charstudy">지문자 연습</a>
+            <a class="btn btn-primary btn-block p-6" href="{{url_for('charstudy')}}">지문자 연습</a>
 <!--          </div>-->
         </div>
         <div class="col-md-4">
 <!--          <div class="btn">-->
-            <a class="btn btn-primary btn-block p-6" href="/quiz">지문자 퀴즈</a>
+            <a class="btn btn-primary btn-block p-6" href="{{url_for('quiz')}}">지문자 퀴즈</a>
 <!--          </div>-->
         </div>
         <div class="col-md-4">
 <!--          <div class="btn">-->
-            <a class="btn btn-primary btn-block p-6" href="/numstudy">숫자 연습</a>
+            <a class="btn btn-primary btn-block p-6" href="{{url_for('numstudy')}}">숫자 연습</a>
 <!--          </div>-->
         </div>
       </div>
@@ -99,7 +99,7 @@
       <hr>
 
       <footer>
-        <p>&copy; 핸들랭(Handlang)</p>
+        <p style="text-align: center;">&copy; 핸들랭(Handlang)</p>
       </footer>
 
 


### PR DESCRIPTION
추후 얘기해봐야 하는 것

1. 학습할 문자 선택하는 페이지 구상

2. 맞았는 걸 계속 맞았다고 안해주고, 틀린 걸 맞았다고 한 거 같은 경우 이를 반영할 버튼?

3. predict라벨과 학습하고 있는 라벨이 같을 경우 8칸짜리 표에서 숫자를 맞았습니다로 변하게 만들기

4. 다른 알파벳들 학습을 왔다갔다하는 페이지를 어떻게 구상할 것인지 

    - ~/b.html, ~c.html 이렇게 가야하는 건가?

 

개인적으로 논의하고 싶은 점

- 숫자 연습과 지문자 연습페이지를 굳이 분리할 필요가 있는가?

- 8번을 다 완료하지 않고 넘어갈때 경고창? "아직 충분히 학습하지 않았는데 넘어가시겠습니다?" 이런 식으로 뜨는 건 어떤지

 

- 2분기 발표 전까지는 보여줄 수 있는 웹페이지를 위해 어느정도 부트스트랩을 익혔으면 역할 나눠서 코딩하는 건 어떤지

    - 학습할 문자 페이지

    - 퀴즈 1 유형

    - 퀴즈 2 유형

    - 숫자 연습(숫자 연습이 그대로 들어갈 경우)

    - 3번 문항 : 맞으면 맞았다 테이블에 반영하는 거

    - 화살표 눌렀을 때 다음 문자로 넘어가기 (4번과 연관)

 